### PR TITLE
Issue 18: implement JSON-RPC API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.bak
 .DS_Store
+*.db
+*~

--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ Dependencies
 
 (not included) [python-bitcoinrpc](https://github.com/jgarzik/python-bitcoinrpc) is used to connect to local bitcoind.
 
+(not included) [python-jsonrpc](https://github.com/gerold-penz/python-jsonrpc) is used to create a JSON-RPC API server.
+
+(not included) [bunch](http://github.com/dsc/bunch) is used by python-jsonrpc
+
 Contributors
 ------------
 
  * Alex "killerstorm" Mizrahi
+ * Jimmy Song
  * Thor "Plazmotech" Correia
  * Victor Knyazhin (coloredcoinlib)
 

--- a/ngccc-server.py
+++ b/ngccc-server.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+from rpc_interface import RPCRequestHandler
+from BaseHTTPServer import HTTPServer
+import json
+
+
+def main():
+    import sys
+    import getopt
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "", [])
+    except getopt.GetoptError:
+        print "arg error"
+        sys.exit(2)
+
+    hostname = args[0]
+    port = int(args[1])
+
+    http_server = HTTPServer(
+        server_address=(hostname, port), RequestHandlerClass=RPCRequestHandler
+    )
+    print "Starting HTTP server on http://%s:%s" % (hostname, port)
+    http_server.serve_forever()
+
+if __name__ == "__main__":
+    main()

--- a/rpc_interface.py
+++ b/rpc_interface.py
@@ -1,0 +1,65 @@
+from wallet_controller import WalletController
+from pwallet import PersistentWallet
+import pyjsonrpc
+import json
+
+wallet = PersistentWallet()
+model = wallet.get_model()
+controller = WalletController(model)
+
+def get_asset_definition(moniker):
+    adm = model.get_asset_definition_manager()
+    asset = adm.get_asset_by_moniker(moniker)
+    if asset:
+        return asset
+    else:
+        raise Exception("asset not found")
+
+def balance(moniker):
+    asset = get_asset_definition(moniker)
+    return controller.get_balance(asset)
+
+def newaddr(moniker):
+    asset = get_asset_definition(moniker)
+    addr = controller.get_new_address(asset)
+    return addr.get_address()
+
+def alladdresses(moniker):
+    asset = get_asset_definition(moniker)
+    return [addr.get_address()
+            for addr in controller.get_all_addresses(asset)]
+
+def addasset(moniker, color_description):
+    controller.add_asset_definition(
+        {"monikers": [moniker],
+         "color_set": [color_description]}
+        )
+
+def dump_config():
+    config = wallet.wallet_config
+    dict_config = dict(config.iteritems())
+    return json.dumps(dict_config, indent=4)
+
+def send(moniker, address, amount):
+    asset = get_asset_definition(moniker)
+    controller.send_coins(address, asset, amount)
+
+def issue(moniker, pck, units, atoms_in_unit):
+    controller.issue_coins(moniker, pck, units, atoms_in_unit)
+
+def scan():
+    controller.scan_utxos()
+
+class RPCRequestHandler(pyjsonrpc.HttpRequestHandler):
+
+    methods = {
+        "balance": balance,
+        "newaddr": newaddr,
+        "alladdresses": alladdresses,
+        "addasset": addasset,
+        "dump_config": dump_config,
+        "send": send,
+        "issue": issue,
+        "scan": scan,
+    }
+


### PR DESCRIPTION
Created a simple python JSON-RPC server script called ngccc-server.py
that allows you to call all the same functions as in ngccc.py but from
a JSON-RPC API.

To start the server run:

python ngccc-server.py localhost 8080

After that, you can connect to localhost:8080 and do JSON-RPC calls.

Note that pyjsonrpc is now required.
