### PR TITLE
Issue #11: parse values.

### DIFF
--- a/console_interface.py
+++ b/console_interface.py
@@ -33,7 +33,7 @@ class CommandInterpreter(object):
 
     def balance(self, args):
         asset = self.get_asset_definition(args[1])
-        print self.controller.get_balance(asset)
+        print asset.format_value(self.controller.get_balance(asset))
 
     def newaddr(self, args):
         asset = self.get_asset_definition(args[1])
@@ -61,7 +61,7 @@ class CommandInterpreter(object):
     def send(self, args):
         asset = self.get_asset_definition(args[1])
         value = int(args[3])
-        self.controller.send_coins(args[2], asset, value)
+        self.controller.send_coins(asset.parse_value(args[2]), asset, value)
 
     def issue(self, args):
         self.controller.issue_coins(args[1], args[2], int(args[3]), int(args[4]))

--- a/wallet_model.py
+++ b/wallet_model.py
@@ -39,6 +39,7 @@ class AssetDefinition(object):
         self.model = model
         self.monikers = params.get('monikers', [])
         self.color_set = ColorSet(model, params.get('color_set'))
+        self.unit = int(params.get('unit', 1))
 
     def get_monikers(self):
         return self.monikers
@@ -69,6 +70,14 @@ class AssetDefinition(object):
                 raise Exception('unable to make transaction constructor for more than one color')
             return txcons.MonocolorTC(self.model, self)
 
+    #returns the atoms (truncate down)
+    def parse_value(self, portion):
+        return int(float(portion) * self.unit)
+
+    #returns a string representation of the portion of the asset.  can envolve rounding.  doesn't display insignificant zeros
+    def format_value(self, atoms):
+        return '{0:g}'.format(atoms / float(self.unit))
+
     def get_data(self):
         return {"monikers": self.monikers,
                         "color_set": self.color_set.get_data()}
@@ -81,7 +90,8 @@ class AssetDefinitionManager(object):
         self.asset_definitions = []
         self.assdef_by_moniker = {}
         btcdef = AssetDefinition(model, {"moniker": "bitcoin",
-                                                                         "color_set": [""]})
+                                                                         "color_set": [""],
+                                                                         "unit": 100000000})
         self.assdef_by_moniker["bitcoin"] = btcdef
         for ad_params in config.get('asset_definitions', []):
             self.register_asset_definition(AssetDefinition(model, ad_params))


### PR DESCRIPTION
Also affects the definition of the "bitcoin" asset to default to full bitcoins.
Also affects the "balance" and "send" commands (not tested!)

Be gentle, I'm new and I'm not sure how you wanted to deal with rounding (there is rounding in both directions) or if you wanted unit to ever be less than 1 (or how unit would be inverted:  should bitcoin use 100000000 or .00000001).  Please let me know what you don't like about the change.  Also be careful, this drastically changes the behavior of the "bitcoin" asset.
