### PR TITLE
Change where setuptools looks for packages to reflect current events.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
 dependency_links=[
     "https://github.com/jgarzik/python-bitcoinrpc/archive/master.zip#egg=python-bitcoinrpc",
     "https://github.com/petertodd/python-bitcoinlib/archive/pythonize.zip#egg=python-bitcoinlib",
-    "https://github.com/jimmysong/pycoin/archive/master.zip#egg=pycoin" # temporary measure until pull request is accepted
+    "https://github.com/jimmysong/pycoin/archive/testnet.zip#egg=pycoin" # temporary measure until pull request is accepted
     ]
 setup(name='ngcccbase',
     version='0.0.1',


### PR DESCRIPTION
I noticed that jimmysong's testnet changes required a change to pycoin which has yet to be accepted. For the moment we can use jimmysong's fork instead (Line 23). Additionally, because petertodd accepted my pull request, I've changed setup.py to point to petertodd's version rather than my fork (Line 22).

If you are already developing using upstream pycoin, you can (In a shell where your virtualenv is activated!!) run `pip uninstall pycoin` then rerun `python setup.py develop` to switch to jimmysong's fork with the changes we need for testnet.
