### PR TITLE
Removed last references to bitcoinrpc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dependencies are automatically retrieved by setup.py.
 
 * [pycoin](https://github.com/richardkiss/pycoin)  is used to work with transactions. (Particularly, sign them.)
 
-* [python-bitcoinrpc](https://github.com/jgarzik/python-bitcoinlib) is used to connect to local bitcoind.
+* [python-bitcoinlib](https://github.com/petertodd/python-bitcoinlib) is used to connect to local bitcoind.
 
 * [python-jsonrpc](https://github.com/gerold-penz/python-jsonrpc) is used to create a JSON-RPC API server.
 

--- a/coloredcoinlib/README.md
+++ b/coloredcoinlib/README.md
@@ -17,7 +17,6 @@ To run this demo you need:
 
  * bitcoind/Bitcoin-Qt with JSON-RPC API, running on testnet, with txindex
    (bitcoind -testnet -txindex -daemon)
- * Jeff Garzic's python-bitcoinrpc library
  * Python 2.x
  * SQLite3 library for Python
 

--- a/coloredcoinlib/blockchain.py
+++ b/coloredcoinlib/blockchain.py
@@ -1,4 +1,3 @@
-from bitcoinrpc import authproxy
 import bitcoin.core
 import bitcoin.serialize
 import bitcoin.rpc

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,10 @@ requires = [
     'pycoin',
     'bunch',
     'python-jsonrpc',
-    'python-bitcoinrpc',
     'python-bitcoinlib',
 ]
 
 dependency_links = [
-    "https://github.com/jgarzik/python-bitcoinrpc/archive/master.zip" +
-    "#egg=python-bitcoinrpc",
     "https://github.com/petertodd/python-bitcoinlib/archive/pythonize.zip" +
     "#egg=python-bitcoinlib",
 ]


### PR DESCRIPTION
I believe no code uses python-bitcoinrpc anymore, the last place I saw it imported was in coloredcoinlib/blockchain.py and no code referenced it or authproxy.
