### PR TITLE
Changed coloredcoinlib.blockchain.BlockchainState

### DIFF
--- a/coloredcoinlib/blockchain.py
+++ b/coloredcoinlib/blockchain.py
@@ -57,13 +57,18 @@ class CTransaction(object):
 
 
 class BlockchainState(object):
-    def __init__(self, url, testnet=False):
+    def __init__(self, bitcoind):
+        self.bitcoind = bitcoind
+        self.cur_height = None
+
+    @classmethod
+    def from_url(cls, url, testnet=False):
         if testnet:
-            self.bitcoind = bitcoin.rpc.RawProxy(
+            bitcoind = bitcoin.rpc.RawProxy(
                 service_url=url, service_port=18332)
         else:
-            self.bitcoind = bitcoin.rpc.RawProxy(service_url=url)
-        self.cur_height = None
+            bitcoind = bitcoin.rpc.RawProxy(service_url=url)
+        return cls(bitcoind)
 
     def get_tx_block_height(self, txhash):
         try:

--- a/coloredcoinlib/builder.py
+++ b/coloredcoinlib/builder.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
     import colormap as cm
     import colordata
 
-    blockchain_state = blockchain.BlockchainState(None, True)
+    blockchain_state = blockchain.BlockchainState.from_url(None, True)
 
     store_conn = store.DataStoreConnection("test-color.db")
     cdstore = store.ColorDataStore(store_conn.conn)

--- a/coloredcoinlib/tests/test_coloredcoinlib.py
+++ b/coloredcoinlib/tests/test_coloredcoinlib.py
@@ -10,7 +10,7 @@ from coloredcoinlib import colordata
 
 class TestColoredCoin(unittest.TestCase):
     def test_coloredcoin(self):
-        blockchain_state = blockchain.BlockchainState(
+        blockchain_state = blockchain.BlockchainState.from_url(
             "http://bitcoinrpc:8oso9n8E1KnTexnKHn16N3tcsGpfEThksK4ojzrkzn3b"
             "@localhost:18332/")
         store_conn = store.DataStoreConnection("color.db") # FIXME: this should be mocked, or should use test data

--- a/wallet_model.py
+++ b/wallet_model.py
@@ -346,7 +346,7 @@ class ColoredCoinContext(object):
         from electrum import EnhancedBlockchainState
 
         if self.testnet:
-            self.blockchain_state = blockchain.BlockchainState(
+            self.blockchain_state = blockchain.BlockchainState.from_url(
                 None, self.testnet)
         else:
             self.blockchain_state = EnhancedBlockchainState(


### PR DESCRIPTION
Changed coloredcoinlib.blockchain.BlockchainState's initializer so that it directly takes a RawProxy, rather than building one itself. I believe this separates concerns better. I added a class method to encapsulate the old functionality, and replaced old calls to the initializer with calls to the class method.
