### PR TITLE
Issue #62: Refactor meat.py

### DIFF
--- a/ecdsa/__init__.py
+++ b/ecdsa/__init__.py
@@ -1,6 +1,6 @@
 
 from keys import SigningKey, VerifyingKey, BadSignatureError, BadDigestError
-from curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p
+from curves import NIST192p, NIST224p, NIST256p, NIST384p, NIST521p, SECP256k1
 
 _hush_pyflakes = [SigningKey, VerifyingKey, BadSignatureError, BadDigestError,
                   NIST192p, NIST224p, NIST256p, NIST384p, NIST521p]

--- a/ngcccbase/tests/test_txdb.py
+++ b/ngcccbase/tests/test_txdb.py
@@ -6,12 +6,16 @@ import sqlite3
 
 from ngcccbase import txdb
 
-import txcons  # FIXME: will explode if not run from main directory
-               #        this is a symptom of dumping stuff in the main
-               #        directory, moving txcons into ngcccbase will
-               #        resolve this
-import utxodb  # FIXME: Same deal as txcons
-import meat    # FIXME: Same as above
+#######################################################
+# FIXME: The following imports
+#        will explode if not run from main directory
+#        this is a symptom of dumping stuff in the main
+#        directory, moving txcons into ngcccbase will
+#        resolve this
+import txcons
+import utxodb
+from address import Address
+######################################################
 
 from coloredcoinlib import txspec
 
@@ -29,8 +33,8 @@ class TestTxDataStoreInitialization(unittest.TestCase):
 
 
 class AddressRec(object):
-    def __init__(self, meat):
-        self.meat = meat
+    def __init__(self, address):
+        self.address = address
 
 
 def fake_transaction(model=None):
@@ -38,10 +42,10 @@ def fake_transaction(model=None):
         "\xe8\x00\xb8\xd4\xa1b\xb7o\x0f;\xf2\xcf\xca\xfd\x1a$\xb9\xa9"
         "\xeb\x0b\x08X\x9f}9C\xe4\x88\xfdD\x11b", curve=ecdsa.curves.SECP256k1)
 
-    address = meat.Address.from_privkey(key)
+    address = Address.fromPrivkey(key)
     script = tools.compile(
         "OP_DUP OP_HASH160 {0} OP_EQUALVERIFY OP_CHECKSIG".format(
-            address.rawPubkey[1:-4].encode("hex"))).encode("hex")
+            address.rawPubkey()[1:-4].encode("hex"))).encode("hex")
     utxo = utxodb.UTXO("D34DB33F", 0, 1, script)
     utxo.address_rec = object()
     utxo.address_rec = AddressRec(address)

--- a/ngcccbase/txdb.py
+++ b/ngcccbase/txdb.py
@@ -59,8 +59,9 @@ class TxDataStore(DataStore):
             txid = self.add_tx(txhash, tx.get_hex_tx_data()).lastrowid
 
             for txin in tx.composed_tx_spec.txins:
-                self.execute(insert_transaction,
-                             (txin.utxo.address_rec.meat.pubkey, TXIN, txid))
+                self.execute(
+                    insert_transaction,
+                    (txin.utxo.address_rec.address.pubkey, TXIN, txid))
 
             for txout in tx.composed_tx_spec.txouts:
                 self.execute(

--- a/txcons.py
+++ b/txcons.py
@@ -165,7 +165,7 @@ class SignedTxSpec(object):
         # sign the transaction using the address's private key
         secret_exponents = [
             encoding.wif_to_tuple_of_secret_exponent_compressed(
-                utxo.address_rec.meat.privkey, is_test=self.testnet)[0]
+                utxo.address_rec.address.privkey, is_test=self.testnet)[0]
             for utxo in input_utxos]
         unsigned_tx = UnsignedTx.standard_tx(
             inputs, outputs, is_test=self.testnet)


### PR DESCRIPTION
Moved meat.py => address.py
Removed all references to meat.
Removed rawPubkey and rawPrivkey and replaced them with functions that calculate them on the fly.
Removed the b58_encode/sha256/md5/ripemd160 functions and started using the pycoin equivalents
