### PR TITLE
Issue #66: Show transaction history for a color

### DIFF
--- a/address.py
+++ b/address.py
@@ -128,6 +128,10 @@ class Address:
 
         return cls(pubkey, privkey)
 
+    @classmethod
+    def rawPubkeyToAddress(cls, raw):
+        return b2a_hashed_base58(cls.PUBLIC_KEY_PREFIX + raw)
+
     def getJSONData(self):
         """Returns a dict that can later be plugged into
         the fromObj method for later retrieval of an Address.
@@ -150,7 +154,7 @@ if __name__ == "__main__":
     address = Address.new(test_key)
     print address.pubkey
     rawPubkey = Address.PUBLIC_KEY_PREFIX + hash160(
-            "\x04" + address.rawPubkey())
+        "\x04" + address.rawPubkey())
     print b2a_hashed_base58(rawPubkey)
     assert address.privkey \
         == "5JZB2s2RCtRUunKiqMbb6rAj3Z7TkJwa8zknL1cfTFpWoQArd6n", \

--- a/coloredcoinlib/blockchain.py
+++ b/coloredcoinlib/blockchain.py
@@ -2,7 +2,6 @@ import bitcoin.core
 import bitcoin.serialize
 import bitcoin.rpc
 
-
 class COutpoint(object):
     def __init__(self, hash, n):
         self.hash = hash
@@ -15,8 +14,13 @@ class CTxIn(object):
 
 
 class CTxOut(object):
-    def __init__(self, value):
+    def __init__(self, value, scriptPubKey=None):
         self.value = value
+        self.raw_address = None
+
+        # extract the destination address from the scriptPubkey
+        if scriptPubKey and scriptPubKey[:3] == "\x76\xa9\x14":
+            self.raw_address = scriptPubKey[3:23]
 
 
 class CTransaction(object):
@@ -41,7 +45,7 @@ class CTransaction(object):
                                        op.n))
         tx.outputs = []
         for o in bctx.vout:
-            tx.outputs.append(CTxOut(o.nValue))
+            tx.outputs.append(CTxOut(o.nValue, o.scriptPubKey))
         return tx
 
     def ensure_input_values(self):

--- a/ngccc-cli.py
+++ b/ngccc-cli.py
@@ -25,7 +25,8 @@ class _ApplicationHelpFormatter(argparse.HelpFormatter):
             argparse.HelpFormatter.add_argument(self, action)
 
     def _format_subparsers(self, action):
-        max_action_width = max([len(x) for x in action._name_parser_map.keys()])
+        max_action_width = max(
+            [len(x) for x in action._name_parser_map.keys()])
 
         parts = []
         for name, subaction in action._name_parser_map.items():
@@ -36,80 +37,94 @@ class _ApplicationHelpFormatter(argparse.HelpFormatter):
 
         return '\n'.join(parts)
 
+
 class Application(object):
     def __init__(self):
         self.args = None
         self.parser = argparse.ArgumentParser(
-            description="Next-Generation Colored Coin Client Command-line interface",
+            description="Next-Generation Colored Coin Client "
+            "Command-line interface",
             formatter_class=_ApplicationHelpFormatter)
 
         self.parser.add_argument("--wallet", dest="wallet_path")
 
-        subparsers = self.parser.add_subparsers(title='subcommands',
-            dest='command')
+        subparsers = self.parser.add_subparsers(
+            title='subcommands', dest='command')
 
-        parser = subparsers.add_parser('import_config',
-            description="Import json config.")
+        parser = subparsers.add_parser(
+            'import_config', description="Import json config.")
         parser.add_argument('path', type=self.validate_import_config_path)
 
-        parser = subparsers.add_parser('setval',
-            description="Sets a value in the configuration.")
+        parser = subparsers.add_parser(
+            'setval', description="Sets a value in the configuration.")
         parser.add_argument('key')
         parser.add_argument('value', type=self.validate_JSON_decode)
 
-        parser = subparsers.add_parser('getval',
-            description="Returns the value for a given key in the config.")
+        parser = subparsers.add_parser(
+            'getval', description=
+            "Returns the value for a given key in the config.")
         parser.add_argument('key')
 
-        parser = subparsers.add_parser('dump_config',
-            description="Returns a JSON dump of the current configuration.")
+        parser = subparsers.add_parser(
+            'dump_config', description=
+            "Returns a JSON dump of the current configuration.")
 
-        parser = subparsers.add_parser('addasset',
-            description="Imports a color definition.")
+        parser = subparsers.add_parser(
+            'addasset', description="Imports a color definition.")
         parser.add_argument('moniker')
         parser.add_argument('color_desc')
         parser.add_argument('unit', type=int)
 
-        parser = subparsers.add_parser('issue',
-            description="Starts a new color.")
+        parser = subparsers.add_parser(
+            'issue', description="Starts a new color.")
         parser.add_argument('moniker')
         parser.add_argument('coloring_scheme')
         parser.add_argument('units', type=int)
         parser.add_argument('atoms', type=int)
 
-        parser = subparsers.add_parser('newaddr',
-            description="Creates a new bitcoin address for a given asset/color.")
+        parser = subparsers.add_parser(
+            'newaddr', description=
+            "Creates a new bitcoin address for a given asset/color.")
         parser.add_argument('moniker')
 
-        parser = subparsers.add_parser('alladdresses',
-            description="Lists all addresses for a given asset/color.")
+        parser = subparsers.add_parser(
+            'alladdresses', description=
+            "Lists all addresses for a given asset/color.")
         parser.add_argument('moniker')
 
-        parser = subparsers.add_parser('balance',
-            description="Returns the balance in Satoshi for a particular asset/color.")
+        parser = subparsers.add_parser(
+            'balance', description=
+            "Returns the balance in Satoshi for a particular asset/color.")
         parser.add_argument('moniker')
 
-        parser = subparsers.add_parser('send',
-            description="Send some amount of an asset/color to an address.")
+        parser = subparsers.add_parser(
+            'send', description=
+            "Send some amount of an asset/color to an address.")
         parser.add_argument('moniker')
         parser.add_argument('address')
         parser.add_argument('value')
 
-        parser = subparsers.add_parser('scan',
-            description="Update the database of transactions (amount in each address).")
+        parser = subparsers.add_parser(
+            'scan', description=
+            "Update the database of transactions (amount in each address).")
 
-        parser = subparsers.add_parser('p2p_show_orders',
-                                       description="Show p2ptrade orders")
+        parser = subparsers.add_parser(
+            'history', description="Shows the history of transactions "
+            "for a particular asset/color in your wallet.")
         parser.add_argument('moniker')
 
-        parser = subparsers.add_parser('p2p_sell',
-                                       description="sell via p2ptrade")
+        parser = subparsers.add_parser(
+            'p2p_show_orders', description="Show p2ptrade orders")
+        parser.add_argument('moniker')
+
+        parser = subparsers.add_parser(
+            'p2p_sell', description="sell via p2ptrade")
         parser.add_argument('moniker')
         parser.add_argument('value')
         parser.add_argument('price')
 
-        parser = subparsers.add_parser('p2p_buy',
-                                       description="buy via p2ptrade")
+        parser = subparsers.add_parser(
+            'p2p_buy', description="buy via p2ptrade")
         parser.add_argument('moniker')
         parser.add_argument('value')
         parser.add_argument('price')
@@ -130,11 +145,11 @@ class Application(object):
                 wallet_model = pw.get_model()
 
                 data.update({
-                    'controller': WalletController(wallet_model) \
-                                    if wallet_model else None,
+                    'controller': WalletController(wallet_model)
+                    if wallet_model else None,
                     'wallet': pw,
                     'model': wallet_model if pw else None,
-                })
+                    })
             return data[name]
         return object.__getattribute__(self, name)
 
@@ -235,8 +250,9 @@ class Application(object):
         a name of <moniker> with <units> per share and <atoms>
         total shares.
         """
-        self.controller.issue_coins(kwargs['moniker'],
-            kwargs['coloring_scheme'], kwargs['units'], kwargs['atoms'])
+        self.controller.issue_coins(
+            kwargs['moniker'], kwargs['coloring_scheme'],
+            kwargs['units'], kwargs['atoms'])
 
     def command_newaddr(self, **kwargs):
         """Creates a new bitcoin address for a given asset/color.
@@ -271,15 +287,24 @@ class Application(object):
         """
         self.controller.scan_utxos()
 
+    def command_history(self, **kwargs):
+        """print the history of transactions for this color
+        """
+        asset = self.get_asset_definition(moniker=kwargs['moniker'])
+        history = self.controller.get_history(asset)
+        for row in history:
+            print "%s %s %s" % (row[0], row[1], row[2])
+
     def init_p2ptrade(self):
         from ngcccbase.p2ptrade.ewctrl import EWalletController
         from ngcccbase.p2ptrade.agent import EAgent
         from ngcccbase.p2ptrade.comm import HTTPExchangeComm
-        
+
         ewctrl = EWalletController(self.model)
         config = {"offer_expiry_interval": 30,
                   "ep_expiry_interval": 30}
-        comm = HTTPExchangeComm(config, 'http://p2ptrade.btx.udoidio.info/messages')
+        comm = HTTPExchangeComm(
+            config, 'http://p2ptrade.btx.udoidio.info/messages')
         agent = EAgent(ewctrl, config, comm)
         return agent
 
@@ -291,7 +316,7 @@ class Application(object):
         price = bitcoin.parse_value(params['price'])
         total = int(float(value)/float(asset.unit)*float(price))
         color_desc = asset.get_color_set().color_desc_list[0]
-        sell_side = {"color_spec": color_desc, "value": value }
+        sell_side = {"color_spec": color_desc, "value": value}
         buy_side = {"color_spec": "", "value": total}
         if we_sell:
             return MyEOffer(None, sell_side, buy_side)

--- a/pwallet.py
+++ b/pwallet.py
@@ -35,8 +35,8 @@ class PersistentWallet(object):
         """Associate the wallet model based on the persistent
         configuration.
         """
-        self.wallet_model = WalletModel(self.wallet_config, 
-                                        self.store_conn)
+        self.wallet_model = WalletModel(
+            self.wallet_config, self.store_conn)
 
     def import_config(self, config):
         """Import JSON configuration <config> into the

--- a/pycoin_txcons.py
+++ b/pycoin_txcons.py
@@ -18,6 +18,7 @@ from pycoin.tx.script.vm import verify_script
 
 from io import BytesIO
 
+
 def construct_standard_tx(composed_tx_spec, is_test):
     txouts = []
     STANDARD_SCRIPT_OUT = "OP_DUP OP_HASH160 %s OP_EQUALVERIFY OP_CHECKSIG"
@@ -33,7 +34,8 @@ def construct_standard_tx(composed_tx_spec, is_test):
     version = 1
     lock_time = 0
     return Tx(version, txins, txouts, lock_time)
-    
+
+
 def sign_tx(tx, utxo_list, is_test):
     secret_exponents = [
         wif_to_tuple_of_secret_exponent_compressed(
@@ -47,21 +49,24 @@ def sign_tx(tx, utxo_list, is_test):
         blank_txin = txins[txin_idx]
         utxo = None
         for utxo_candidate in utxo_list:
-            if (utxo_candidate.get_txhash() == blank_txin.previous_hash and
-                utxo_candidate.outindex == blank_txin.previous_index):
+            if utxo_candidate.get_txhash() == blank_txin.previous_hash \
+                    and utxo_candidate.outindex == blank_txin.previous_index:
                 utxo = utxo_candidate
                 break
         if not (utxo and utxo.address_rec):
             continue
         txout_script = utxo.script.decode('hex')
-        signature_hash = tx.signature_hash(txout_script, txin_idx, hash_type=hash_type)
+        signature_hash = tx.signature_hash(
+            txout_script, txin_idx, hash_type=hash_type)
         txin_script = solver(txout_script, signature_hash, hash_type)
         txins[txin_idx] = TxIn(blank_txin.previous_hash,
                                blank_txin.previous_index,
                                txin_script)
-        if not verify_script(txin_script, txout_script, signature_hash, hash_type=hash_type):
+        if not verify_script(txin_script, txout_script,
+                             signature_hash, hash_type=hash_type):
             raise Exception("invalid script")
     tx.txs_in = txins
+
 
 def deserialize(tx_data):
     return Tx.parse(BytesIO(tx_data))

--- a/rpc_interface.py
+++ b/rpc_interface.py
@@ -141,6 +141,13 @@ def scan():
     controller.scan_utxos()
 
 
+def history(self, **kwargs):
+    """print the history of transactions for this color
+    """
+    asset = self.get_asset_definition(moniker=kwargs['moniker'])
+    return self.controller.get_history(asset)
+
+
 class RPCRequestHandler(pyjsonrpc.HttpRequestHandler):
     """JSON-RPC handler for ngccc's commands.
     The command-set is identical to the console interface.
@@ -157,4 +164,5 @@ class RPCRequestHandler(pyjsonrpc.HttpRequestHandler):
         "send": send,
         "issue": issue,
         "scan": scan,
+        "history": history,
     }

--- a/txcons.py
+++ b/txcons.py
@@ -169,11 +169,10 @@ class RawTxSpec(object):
         return cls(model, pycoin_tx)
 
     def sign(self, utxo_list):
-        pycoin_txcons.sign_tx(self.pycoin_tx,
-                              utxo_list,                              
-                              self.model.is_testnet())
+        pycoin_txcons.sign_tx(
+            self.pycoin_tx, utxo_list, self.model.is_testnet())
         self.update_tx_data()
-    
+
     def get_tx_data(self):
         """Returns the signed transaction data.
         """
@@ -202,7 +201,7 @@ def compose_uncolored_tx(tx_spec):
             txspec.ComposedTxSpec.TxOut(
                 change, tx_spec.get_change_addr(0)))
     return txspec.ComposedTxSpec(txins, txouts)
-        
+
 
 class TransactionSpecTransformer(object):
     """An object that can transform one type of transaction into another.

--- a/wallet_controller.py
+++ b/wallet_controller.py
@@ -67,8 +67,8 @@ class WalletController(object):
             color_desc = ':'.join(['obc', genesis_tx_hash, '0', str(height)])
             adm = self.model.get_asset_definition_manager()
             asset = adm.add_asset_definition({"monikers": [moniker],
-                                               "color_set": [color_desc],
-                                               "unit": atoms_in_unit})
+                                              "color_set": [color_desc],
+                                              "unit": atoms_in_unit})
             wam.update_genesis_address(address, asset.get_color_set())
         else:
             raise Exception('color scheme not recognized')
@@ -103,3 +103,9 @@ class WalletController(object):
         utxo_list = cq.get_result()
         value_list = [asset.get_utxo_value(utxo) for utxo in utxo_list]
         return sum(value_list)
+
+    def get_history(self, asset):
+        """Returns the history of an asset for all addresses of that color
+        in this wallet
+        """
+        return self.model.get_history_for_asset(asset)

--- a/wallet_model.py
+++ b/wallet_model.py
@@ -539,7 +539,7 @@ class WalletModel(object):
     def __init__(self, config, store_conn):
         """Creates a new wallet given a configuration <config>
         """
-        self.store_conn = store_conn #  hackish!
+        self.store_conn = store_conn  # hackish!
         self.ccc = ColoredCoinContext(config)
         self.ass_def_man = AssetDefinitionManager(self, config)
         self.address_man = DWalletAddressManager(self, config)
@@ -584,6 +584,61 @@ class WalletModel(object):
         """Access method for address manager
         """
         return self.address_man
+
+    def get_history_for_asset(self, asset):
+        """Returns the history of how an address got its coins.
+        """
+        klass = TestnetAddress if self.testnet else Address
+
+        history = []
+
+        address_lookup = {
+            a.get_address(): 1 for a in
+            self.address_man.get_addresses_for_color_set(
+                asset.get_color_set())}
+
+        for color in asset.color_set.color_id_set:
+            colordef = self.ccc.colormap.get_color_def(color)
+            seen_hashes = {}
+            for row in reversed(self.ccc.cdstore.get_all(color)):
+                # address_ledger will keep track of the net
+                #  affect on an address
+                address_ledger = {}
+                appended = 0
+                txhash = row[0]
+                if seen_hashes.get(txhash):
+                    continue
+                seen_hashes[txhash] = 1
+                tx = self.ccc.blockchain_state.get_tx(txhash)
+                for output in tx.outputs:
+                    # find out where it went into
+                    address = klass.rawPubkeyToAddress(output.raw_address)
+
+                    if address_lookup.get(address):
+                        address_ledger[address] = \
+                            address_ledger.get(address, 0) + output.value
+
+                for input in tx.inputs:
+                    # find the hash referred to by the input
+                    outpoint = input.outpoint
+                    intx = self.ccc.blockchain_state.get_tx(outpoint.hash)
+                    output = intx.outputs[outpoint.n]
+                    address = klass.rawPubkeyToAddress(output.raw_address)
+                    if address_lookup.get(address):
+                        address_ledger[address] = \
+                            address_ledger.get(address, 0) - output.value
+
+                for address, value in address_ledger.items():
+                    if value < 0:
+                        history.append(["sent", -value, address])
+                    elif txhash == colordef.genesis['txhash']:
+                        history.append(["issued", value, address])
+                    else:
+                        history.append(["received", value, address])
+
+                if len(address_ledger) == 0:
+                    history.append(["unknown", txhash, ""])
+        return history
 
     def get_color_map(self):
         """Access method for ColoredCoinContext's colormap


### PR DESCRIPTION
Added a get_history_for_asset method in wallet_model which does most of the work.

Modified coloredcoinlib/blockchain.py to add a raw_address element to CTxOut.
This element is recorded from scriptPubKey which is in the raw transaction from bitcoincore.
This allows us to tie back transactions to addresses later on.

The actual getting history only shows the NET AFFECT on an address. So if an address
sent 1000 of color A coins and receives back 800 of color A coins, we'll only show that
color A sent 200 of color A coins.

Note I haven't implemented the scanhistory method. I don't think that's really necessary
since it's scan and then history of asset.

Also did pep8 on a few files.
