### PR TITLE
Issue #6: Rely on blockhash instead of block height for backscanning.

### DIFF
--- a/coloredcoinlib/builder.py
+++ b/coloredcoinlib/builder.py
@@ -21,18 +21,18 @@ class ColorDataBuilderManager(object):
     def get_builder(self, color_id):
         if color_id in self.builders:
             return self.builders[color_id]
-        colordef = self.colormap.get_color_def(color_id)
+        colordef = self.colormap.get_color_def(color_id, self.blockchain_state)
         builder = self.builder_class(
             self.cdstore, self.blockchain_state, colordef, self.metastore)
         self.builders[color_id] = builder
         return builder
 
-    def ensure_scanned_upto(self, color_id_set, block_height):
+    def ensure_scanned_upto(self, color_id_set, blockhash):
         for color_id in color_id_set:
             if color_id == 0:
                 continue
             builder = self.get_builder(color_id)
-            builder.ensure_scanned_upto(block_height)
+            builder.ensure_scanned_upto(blockhash)
 
 
 class BasicColorDataBuilder(ColorDataBuilder):
@@ -67,44 +67,50 @@ class FullScanColorDataBuilder(BasicColorDataBuilder):
         super(FullScanColorDataBuilder, self).__init__(
             cdstore, blockchain_state, colordef)
         self.metastore = metastore
-        self.cur_height = metastore.get_scan_height(self.color_id)
 
-    def scan_blockchain(self, from_height, to_height):
-        for i in xrange(from_height, to_height + 1):
-            self.scan_block(i)
-
-    def scan_block(self, height):
-        log("scanning block at height %s" % height)
-        for tx in self.blockchain_state.iter_block_txs(height):
+    def scan_block(self, blockhash):
+        height = self.blockchain_state.get_block_height(blockhash)
+        print "scanning block %s at %s" % (blockhash, height)
+        for tx in self.blockchain_state.iter_block_txs(blockhash):
             self.scan_tx(tx)
-        self.cur_height = height
-        self.metastore.set_scan_height(self.color_id, self.cur_height)
+        self.metastore.set_as_scanned(self.color_id, blockhash)
 
-    def ensure_scanned_upto(self, block_height):
-        if self.cur_height >= block_height:
-            pass  # up-to-date
-        else:
-            if self.cur_height:
-                from_height = self.cur_height + 1
-            else:
-                # we cannot get genesis block via RPC, so we start from block 1
-                from_height = self.colordef.starting_height or 1
-            self.scan_blockchain(from_height, block_height)
+    def scan_blockchain(self, blocklist):
+        for blockhash in blocklist:
+            self.scan_block(blockhash)
+
+    def ensure_scanned_upto(self, final_blockhash):
+        if self.metastore.did_scan(self.color_id, final_blockhash):
+            return
+        min_height = self.colordef.genesis['height']
+
+        # start from the final_blockhash and go backwards to build up
+        #  the list of blocks to scan
+        blockhash = final_blockhash
+        blocklist = []
+        while not self.metastore.did_scan(self.color_id, blockhash):
+            blocklist.insert(0, blockhash)
+            blockhash = self.blockchain_state.get_previous_blockhash(
+                blockhash)
+            height = self.blockchain_state.get_block_height(blockhash)
+            if height < min_height:
+                break
+
+        self.scan_blockchain(blocklist)
 
 
 class AidedColorDataBuilder(FullScanColorDataBuilder):
     """color data builder based on following output spending transactions,
        for one specific color"""
 
-    def scan_blockchain(self, from_height, to_height):
+    def scan_blockchain(self, blocklist):
         txo_queue = [self.colordef.genesis]
-        for cur_block_height in xrange(self.colordef.starting_height,
-                                       to_height + 1):
+        for blockhash in blocklist:
             # remove txs from this block from the queue
             block_txo_queue = [txo for txo in txo_queue
-                               if txo['height'] == cur_block_height]
+                               if txo['blockhash'] == blockhash]
             txo_queue = [txo for txo in txo_queue
-                         if txo['height'] != cur_block_height]
+                         if txo['blockhash'] != blockhash]
 
             block_txos = {}
             while block_txo_queue:
@@ -115,7 +121,7 @@ class AidedColorDataBuilder(FullScanColorDataBuilder):
                 block_txos[txo['txhash']] = txo
                 spends = get_spends(txo['txhash'], self.blockchain_state)
                 for stxo in spends:
-                    if stxo['height'] == cur_block_height:
+                    if stxo['blockhash'] == blockhash:
                         block_txo_queue.append(stxo)
                     else:
                         txo_queue.append(stxo)

--- a/coloredcoinlib/colordata.py
+++ b/coloredcoinlib/colordata.py
@@ -5,11 +5,10 @@ class ThickColorData(object):
         self.cdstore = cdstore
 
     def get_colorvalues(self, color_id_set, txhash, outindex):
-        block_height, in_mempool = \
-            self.blockchain_state.get_tx_block_height(txhash)
-        if block_height:
+        blockhash = self.blockchain_state.get_tx_blockhash(txhash)
+        if blockhash:
             self.cdbuilder_manager.ensure_scanned_upto(
-                color_id_set, block_height)
+                color_id_set, blockhash)
             res = self.cdstore.get_any(txhash, outindex)
             return [entry for entry in res
                     if entry[0] in color_id_set]

--- a/coloredcoinlib/colormap.py
+++ b/coloredcoinlib/colormap.py
@@ -18,7 +18,7 @@ class ColorMap(object):
         else:
             return self.metastore.resolve_color_desc(color_desc, auto_add)
 
-    def get_color_def(self, color_id_or_desc):
+    def get_color_def(self, color_id_or_desc, blockchain_state):
         if color_id_or_desc == 0:
             return None
         color_id = color_id_or_desc
@@ -32,6 +32,7 @@ class ColorMap(object):
             color_desc = self.find_color_desc(color_id)
             if not color_desc:
                 raise Exception("color id not found")
-        cd = ColorDefinition.from_color_desc(color_id, color_desc)
+        cd = ColorDefinition.from_color_desc(
+            color_id, color_desc, blockchain_state)
         self.colordefs[color_id] = cd
         return cd

--- a/coloredcoinlib/explorer.py
+++ b/coloredcoinlib/explorer.py
@@ -13,5 +13,5 @@ def get_spends(tx, blockchain_state):
         ret.append(
             {'txhash': tx_hash,
              'outindex': output_n,
-             'height': blockchain_state.get_tx_block_height(tx_hash)[0]})
+             'blockhash': blockchain_state.get_tx_blockhash(tx_hash)[0]})
     return ret

--- a/ngccc-cli.py
+++ b/ngccc-cli.py
@@ -165,7 +165,7 @@ class Application(object):
             raise Exception("asset not found")
 
     def validate_import_config_path(self, path):
-        return self.validate_JSON_decode(self.validate_file_read())
+        return self.validate_JSON_decode(self.validate_file_read(path))
 
     def validate_file_read(self, path):
         try:

--- a/ngcccbase/p2ptrade/ewctrl.py
+++ b/ngcccbase/p2ptrade/ewctrl.py
@@ -33,12 +33,14 @@ class OperationalETxSpec(txspec.OperationalTxSpec):
         colormap = self.model.get_color_map()
         for tgt_spec in etx_spec.targets:
             tgt_color_id = list(self.ewctrl.resolve_color_spec(tgt_spec[1]).color_id_set)[0]
-            tgt_color_def = colormap.get_color_def(tgt_color_id)
+            tgt_color_def = colormap.get_color_def(
+                tgt_color_id, self.model.ccc.blockchain_state)
             self.targets.append((tgt_spec[0], tgt_color_def, tgt_spec[2]))
         their_color_set = self.ewctrl.resolve_color_spec(their['color_spec'])
         wam = self.model.get_address_manager()
         their_color_id =  list(their_color_set.color_id_set)[0]
-        their_color_def = colormap.get_color_def(their_color_id)
+        their_color_def = colormap.get_color_def(
+            their_color_id, self.model.ccc.blockchain_state)
         self.targets.append(
             (wam.get_change_address(their_color_set).get_address(), their_color_def,
              their['value']))

--- a/txcons.py
+++ b/txcons.py
@@ -83,7 +83,8 @@ class SimpleOperationalTxSpec(txspec.OperationalTxSpec):
         in Satoshi worth of colored coins.
         """
         if not isinstance(color_id, colordef.ColorDefinition):
-            cdef = self.model.get_color_map().get_color_def(color_id)
+            cdef = self.model.get_color_map().get_color_def(
+                color_id, self.model.ccc.blockchain_state)
         else:
             cdef = color_id
         self.targets.append((target_addr, cdef, colorvalue))

--- a/wallet_model.py
+++ b/wallet_model.py
@@ -598,7 +598,8 @@ class WalletModel(object):
                 asset.get_color_set())}
 
         for color in asset.color_set.color_id_set:
-            colordef = self.ccc.colormap.get_color_def(color)
+            colordef = self.ccc.colormap.get_color_def(
+                color, self.ccc.blockchain_state)
             seen_hashes = {}
             for row in reversed(self.ccc.cdstore.get_all(color)):
                 # address_ledger will keep track of the net


### PR DESCRIPTION
Changed the builder_state table to use the blockhash column instead of height.
Changed the color definition to include blockhash and height.
Removed most instances of height, except to check for orphaned blocks.
Added a check for orphaned blocks in case a color was created in an orphan block.
