### PR TITLE
Issue #87: Make a method that takes a pycoin tx and converts to a compos...

### DIFF
--- a/coloredcoinlib/blockchain.py
+++ b/coloredcoinlib/blockchain.py
@@ -7,6 +7,14 @@ import bitcoin.serialize
 import bitcoin.rpc
 
 
+def script_to_raw_address(script):
+    # extract the destination address from the scriptPubkey
+    if script[:3] == "\x76\xa9\x14":
+        return script[3:23]
+    else:
+        return None
+
+
 class COutpoint(object):
     def __init__(self, hash, n):
         self.hash = hash
@@ -19,13 +27,10 @@ class CTxIn(object):
 
 
 class CTxOut(object):
-    def __init__(self, value, scriptPubKey=None):
+    def __init__(self, value, script):
         self.value = value
-        self.raw_address = None
-
-        # extract the destination address from the scriptPubkey
-        if scriptPubKey and scriptPubKey[:3] == "\x76\xa9\x14":
-            self.raw_address = scriptPubKey[3:23]
+        self.script = script
+        self.raw_address = script_to_raw_address(script)
 
 
 class CTransaction(object):

--- a/coloredcoinlib/txspec.py
+++ b/coloredcoinlib/txspec.py
@@ -1,4 +1,5 @@
 """ Transaction specification language """
+from blockchain import script_to_raw_address
 
 
 class OperationalTxSpec(object):
@@ -58,3 +59,32 @@ class ComposedTxSpec(object):
 
     def get_txouts(self):
         return self.txouts
+
+    @classmethod
+    def from_pycoin_tx(cls, ccc, pycoin_tx):
+        txins, txouts = [], []
+
+        for py_txin in pycoin_tx.txs_in:
+            # lookup the previous hash and generate the utxo
+            in_txhash, in_outindex = py_txin.previous_hash, py_txin.previous_index
+            in_tx = ccc.blockchain_state.get_tx(in_txhash)
+            value = in_tx.outputs[in_outindex].value
+            raw_address = script_to_raw_address(py_txin.script)
+            address = ccc.raw_to_address(raw_address)
+
+            utxo = {
+                'txhash': in_txhash,
+                'outindex': in_outindex,
+                'address': address,
+                'value': value,
+                'script': py_txin.script.encode('hex'),
+                'scantime': -1,
+                'commitment': -1,
+                }
+            txins.append(TxIn(utxo))
+        for py_txout in pycoin_tx.txs_out:
+            script = py_txout.script
+            raw_address = script_to_raw_address(script)
+            address = ccc.raw_to_address(raw_address)
+            txouts.append(TxOut(py_txout.coin_value, address))
+        return cls(txins, txouts)

--- a/txcons.py
+++ b/txcons.py
@@ -173,7 +173,8 @@ class RawTxSpec(object):
     @classmethod
     def from_tx_data(cls, model, tx_data):
         pycoin_tx = pycoin_txcons.deserialize(tx_data)
-        return cls(model, pycoin_tx)
+        composed_tx_spec = txspec.ComposedTxSpec.from_pycoin_tx(model.ccc, pycoin_tx)
+        return cls.from_composed_tx_spec(model, composed_tx_spec)
 
     def sign(self, utxo_list):
         pycoin_txcons.sign_tx(
@@ -329,3 +330,4 @@ class TransactionSpecTransformer(object):
             return self.transform_composed(tx_spec, target_spec_kind)
         elif spec_kind == 'signed':
             return self.transform_signed(tx_spec, target_spec_kind)
+


### PR DESCRIPTION
...edTxSpec

Unfortunately, there's no way to do this in txspec.py without the coloredcoincontext. This is because Address depends on whether we're on testnet or not.
Similarly, the call to blockchain_state's get_tx is unavoidable. That is how we get the actual value of the utxo.
Even in pycoin's own scripts/send.py, it uses a call out to blockchain.info in order to get the actual amount that's available in the utxo.

I'm not exactly sure how to test it or in what context a call like this would happen. Please let me know what I can do to do that.
