### PR TITLE
Issue #78: apply_tx for txhash in mempool

### DIFF
--- a/coloredcoinlib/blockchain.py
+++ b/coloredcoinlib/blockchain.py
@@ -25,6 +25,9 @@ class CTxIn(object):
     def __init__(self, op_hash, op_n):
         self.prevout = COutpoint(op_hash, op_n)
 
+    def get_txhash(self):
+        return self.prevout.hash
+
     def get_outpoint(self):
         return (self.prevout.hash, self.prevout.n)
 

--- a/utxodb.py
+++ b/utxodb.py
@@ -19,6 +19,7 @@ of each colored coin we have.
 
 from coloredcoinlib.store import DataStore, DataStoreConnection
 from coloredcoinlib.txspec import ComposedTxSpec
+from txcons import RawTxSpec
 from time import time
 from ngcccbase.services.blockchain import BlockchainInfoInterface, AbeInterface
 from ngcccbase.services.electrum import ElectrumInterface
@@ -272,22 +273,44 @@ class UTXOManager(object):
         alladdresses = wam.get_all_addresses()
         for address in alladdresses:
             self.update_address(address)
+        mempool = self.model.ccc.blockchain_state.get_mempool_txs()
+        dels = []
+        # we have no guarantee of the order in which the hashes appear on
+        #  the mempool, so we have to get the deletes back and do them
+        #  again
+        for h in mempool:
+            dels += self.apply_tx(h)
 
-    def apply_tx(self, txhash, tx):
+        for item in dels:
+            self.store.del_utxo(*item)
+
+    def apply_tx(self, txhash, tx=None):
         """Given a transaction <composed_tx_spec>, delete any
         utxos that it spends and add any utxos that are new
         """
 
+        all_addresses = [a.get_address() for a in
+                         self.model.get_address_manager().get_all_addresses()]
+
+        if not tx:
+            bs = self.model.ccc.blockchain_state
+            raw_tx = bs.bitcoind.getrawtransaction(txhash, 0).decode('hex')
+            tx = RawTxSpec.from_tx_data(self.model, raw_tx)
+
+        dels = []
         # delete the spent utxo from the db
         for txin in tx.composed_tx_spec.txins:
+            dels.append(txin.get_outpoint())
             oldtxhash, outindex = txin.get_outpoint()
             self.store.del_utxo(oldtxhash, outindex)
 
         # put the new utxo into the db
         for i, txout in enumerate(tx.composed_tx_spec.txouts):
             script = tx.pycoin_tx.txs_out[i].script.encode('hex')
-            self.store.add_utxo(txout.target_addr, txhash, i,
-                                txout.value, script)
+            if txout.target_addr in all_addresses:
+                self.store.add_utxo(txout.target_addr, txhash, i,
+                                    txout.value, script)
+        return dels
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
added a way to make a ComposedTxSpec from pycoin_tx
added mempool transactions when you scan
Note mempool transactions have no guaranteed order, which doesn't affect adds into the utxodb but it does affect the deletes. We simply do all the deletes again at the end.
