### PR TITLE
Issue #103: sort mempool

### DIFF
--- a/coloredcoinlib/builder.py
+++ b/coloredcoinlib/builder.py
@@ -47,11 +47,14 @@ class ColorDataBuilderManager(object):
             builder.ensure_scanned_upto(blockhash)
 
     def scan_txhash(self, color_id_set, txhash):
+        tx = self.blockchain_state.get_tx(txhash)
+        self.scan_tx(color_id_set, tx)
+
+    def scan_tx(self, color_id_set, tx):
         for color_id in color_id_set:
             if color_id == 0:
                 continue
             builder = self.get_builder(color_id)
-            tx = self.blockchain_state.get_tx(txhash)
             builder.scan_tx(tx)
 
 

--- a/coloredcoinlib/colordata.py
+++ b/coloredcoinlib/colordata.py
@@ -45,15 +45,16 @@ class ThickColorData(StoredColorData):
                 best_blockhash = self.blockchain_state.get_best_blockhash()
                 if best_blockhash_prev == best_blockhash:
                     break
-            if txhash not in mempool:
+            if txhash not in [tx.hash for tx in mempool]:
                 raise Exception("transaction %s isn't found in mempool" % txhash)
             # the preceding blockchain
             self.cdbuilder_manager.ensure_scanned_upto(
                 color_id_set, best_blockhash)
             # scan everything in the mempool
-            for h in mempool:
-                self.cdbuilder_manager.scan_txhash(color_id_set, h)
+            for tx in mempool:
+                self.cdbuilder_manager.scan_tx(color_id_set, tx)
             return self._fetch_colorvalues(color_id_set, txhash, outindex)
+
 
 class ThinColorData(StoredColorData):
     """ Color data which needs access to the blockchain state up to the genesis of


### PR DESCRIPTION
Make the mempool transactions sort by dependency
Change history to also use the same dependency sort (toposort)
Change get_mempool_txs to return transactions, not just their hashes
