### PR TITLE
Issue #108: Fix the zero balance problem

### DIFF
--- a/wallet_model.py
+++ b/wallet_model.py
@@ -469,6 +469,7 @@ class DWalletAddressManager(object):
         self.update_config()
         address = self.get_genesis_address(index)
         address.index = index
+        self.addresses.append(address)
         return address
 
     def update_genesis_address(self, address, color_set):


### PR DESCRIPTION
Turns out that the list of addresses where we pull the balance from is missing the genesis address for the issued color. Adding it fixes the problem.
