### PR TITLE
Issue #121: Move ColorSet out of Wallet Model and put it into coloredcoi...

### DIFF
--- a/coloredcoinlib/__init__.py
+++ b/coloredcoinlib/__init__.py
@@ -1,3 +1,11 @@
 """
 coloredcoinlib module provides the core colored coin functionality and tools.
 """
+
+from blockchain import BlockchainState
+from builder import ColorDataBuilderManager, FullScanColorDataBuilder
+from colordata import ThickColorData
+from colormap import ColorMap
+from colorset import ColorSet
+from store import DataStoreConnection, ColorDataStore, ColorMetaStore
+from toposort import toposorted

--- a/coloredcoinlib/colorset.py
+++ b/coloredcoinlib/colorset.py
@@ -1,0 +1,94 @@
+import hashlib
+import json
+
+from pycoin.encoding import b2a_base58
+
+
+def deterministic_json_dumps(obj):
+    """TODO: make it even more deterministic!"""
+    return json.dumps(obj, separators=(',', ':'), sort_keys=True)
+
+
+class ColorSet(object):
+    """A set of colors which belong to certain a asset.
+    It can be used to filter addresses and UTXOs
+    """
+    def __init__(self, colormap, color_desc_list):
+        """Creates a new color set given a color map <colormap>
+        and color descriptions <color_desc_list>
+        """
+        self.color_desc_list = color_desc_list
+        self.color_id_set = set()
+        for color_desc in color_desc_list:
+            color_id = colormap.resolve_color_desc(color_desc)
+            self.color_id_set.add(color_id)
+
+    def __repr__(self):
+        return self.color_desc_list.__repr__()
+
+    def uncolored_only(self):
+        return self.color_id_set == set([0])
+
+    def get_data(self):
+        """Returns a list of strings that describe the colors.
+        e.g. ["obc:f0bd5...a5:0:128649"]
+        """
+        return self.color_desc_list
+
+    def get_hash_string(self):
+        """Returns a deterministic string for this color set.
+        Useful for creating deterministic addresses for a given color.
+        """
+        json = deterministic_json_dumps(sorted(self.color_desc_list))
+        return hashlib.sha256(json).hexdigest()
+
+    def get_earliest(self):
+        """Returns the color description of the earliest color to
+        show in the blockchain. If there's a tie and two are issued
+        in the same block, go with the one that has a smaller txhash
+        """
+        all_descs = self.get_data()
+        if not len(all_descs):
+            return "\x00\x00\x00\x00"
+        best = all_descs[0]
+        best_components = best.split(':')
+        for desc in all_descs[1:]:
+            components = desc.split(':')
+            if int(components[3]) < int(best_components[3]):
+                best = desc
+            elif int(components[3]) == int(best_components[3]):
+                if cmp(components[1], best_components[1]) == -1:
+                    best = desc
+        return best
+
+    def get_color_hash(self):
+        """Returns the hash used in color addresses.
+        """
+        return b2a_base58(self.get_hash_string().decode('hex')[:10])
+
+    def has_color_id(self, color_id):
+        """Returns boolean of whether color <color_id> is associated
+        with this color set.
+        """
+        return (color_id in self.color_id_set)
+
+    def intersects(self, other):
+        """Given another color set <other>, returns whether
+        they share a color in common.
+        """
+        return len(self.color_id_set & other.color_id_set) > 0
+
+    def equals(self, other):
+        """Given another color set <other>, returns whether
+        they are the exact same color set.
+        """
+        return self.color_id_set == other.color_id_set
+
+    @classmethod
+    def from_color_ids(cls, colormap, color_ids):
+        """Given a colormap <colormap> and a list of colors <color_ids>
+        return a ColorSet object.
+        """
+        color_desc_list = [colormap.find_color_desc(color_id)
+                           for color_id in color_ids]
+        return cls(colormap, color_desc_list)

--- a/coloredcoinlib/tests/test_colorset.py
+++ b/coloredcoinlib/tests/test_colorset.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+import unittest
+
+from coloredcoinlib import ColorSet
+
+
+class MockColorMap:
+    def __init__(self, *args, **kwargs):
+        self.d = {0:""}
+        self.r = {"":0}
+        for i in range(1,10):
+            s = "obc:color_desc_%s:0:%s" % (i,i // 2)
+            self.d[i] = s
+            self.r[s] = i
+
+    def find_color_desc(self, color_id):
+        return self.d[color_id]
+
+    def resolve_color_desc(self, color_desc, auto_add=True):
+        return self.r[color_desc]
+
+
+class TestColorSet(unittest.TestCase):
+
+    def setUp(self):
+        self.colormap = MockColorMap()
+        d = self.colormap.d
+        self.colorset0 = ColorSet(self.colormap, [d[0]])
+        self.colorset1 = ColorSet(self.colormap, [d[1]])
+        self.colorset2 = ColorSet(self.colormap, [d[2]])
+        self.colorset3 = ColorSet(self.colormap, [d[1], d[2]])
+        self.colorset4 = ColorSet(self.colormap, [d[3], d[2]])
+        self.colorset5 = ColorSet(self.colormap, [d[3], d[1]])
+        self.colorset6 = ColorSet(self.colormap, [])
+
+    def test_repr(self):
+        self.assertEquals(self.colorset0.__repr__(), "['']")
+        self.assertEquals(self.colorset1.__repr__(),
+                          "['obc:color_desc_1:0:0']")
+        self.assertEquals(self.colorset3.__repr__(),
+                          "['obc:color_desc_1:0:0', 'obc:color_desc_2:0:1']")
+
+    def test_uncolored_only(self):
+        self.assertTrue(self.colorset0.uncolored_only())
+        self.assertTrue(not self.colorset1.uncolored_only())
+        self.assertTrue(not self.colorset3.uncolored_only())
+
+    def test_get_data(self):
+        self.assertEquals(self.colorset0.get_data(), [""])
+        self.assertEquals(self.colorset1.get_data(), ["obc:color_desc_1:0:0"])
+
+    def test_get_hash_string(self):
+        self.assertEquals(self.colorset0.get_hash_string(), "055539df4a0b804c58caf46c0cd2941af10d64c1395ddd8e50b5f55d945841e6")
+        self.assertEquals(self.colorset1.get_hash_string(), "ca90284eaa79e05d5971947382214044fe64f1bdc2e97040cfa9f90da3964a14")
+        self.assertEquals(self.colorset3.get_hash_string(), "09f731f25cf5bfaad512d4ee6f37cb9481f442df3263b15725dd1624b4678557")
+
+    def test_get_earliest(self):
+        self.assertEquals(self.colorset5.get_earliest(), "obc:color_desc_1:0:0")
+        self.assertEquals(self.colorset4.get_earliest(), "obc:color_desc_2:0:1")
+        self.assertEquals(self.colorset6.get_earliest(), "\x00\x00\x00\x00")
+
+    def test_get_color_string(self):
+        self.assertEquals(self.colorset0.get_color_hash(), "JNu4AFCBNmTE1")
+        self.assertEquals(self.colorset1.get_color_hash(), "CP4YWLr8aAe4Hn")
+        self.assertEquals(self.colorset3.get_color_hash(), "ZUTSoEEwZY6PB")
+
+    def test_has_color_id(self):
+        self.assertTrue(self.colorset0.has_color_id(0))
+        self.assertTrue(self.colorset3.has_color_id(1))
+        self.assertTrue(not self.colorset1.has_color_id(0))
+        self.assertTrue(not self.colorset4.has_color_id(1))
+
+    def test_intersects(self):
+        self.assertTrue(not self.colorset0.intersects(self.colorset1))
+        self.assertTrue(self.colorset1.intersects(self.colorset3))
+        self.assertTrue(self.colorset3.intersects(self.colorset1))
+        self.assertTrue(self.colorset4.intersects(self.colorset3))
+        self.assertTrue(not self.colorset2.intersects(self.colorset0))
+        self.assertTrue(not self.colorset1.intersects(self.colorset4))
+
+    def test_equals(self):
+        self.assertTrue(not self.colorset1.equals(self.colorset0))
+        self.assertTrue(self.colorset3.equals(self.colorset3))
+        self.assertTrue(not self.colorset4.equals(self.colorset5))
+        
+    def test_from_color_ids(self):
+        self.assertTrue(self.colorset0.equals(
+                ColorSet.from_color_ids(self.colormap, [0])))
+        self.assertTrue(self.colorset3.equals(
+                ColorSet.from_color_ids(self.colormap, [1,2])))
+        tmp = ColorSet.from_color_ids(self.colormap, [1,2,3])
+        self.assertTrue(tmp.has_color_id(1))
+        self.assertTrue(tmp.has_color_id(2))
+        self.assertTrue(tmp.has_color_id(3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ngcccbase/p2ptrade/ewctrl.py
+++ b/ngcccbase/p2ptrade/ewctrl.py
@@ -1,6 +1,5 @@
-from coloredcoinlib import txspec
+from coloredcoinlib import txspec, ColorSet
 from collections import defaultdict
-from ngcccbase.wallet_model import ColorSet
 from protocol_objects import ETxSpec
 from ngcccbase.utxodb import UTXO
 
@@ -17,7 +16,7 @@ class OperationalETxSpec(txspec.OperationalTxSpec):
 
     def get_change_addr(self, color_def):
         color_id = color_def.color_id
-        cs = ColorSet.from_color_ids(self.model, [color_id])
+        cs = ColorSet.from_color_ids(self.model.get_color_map(), [color_id])
         wam = self.model.get_address_manager()
         return wam.get_change_address(cs).get_address()
 
@@ -96,7 +95,7 @@ class EWalletController(object):
         color_id = colormap.resolve_color_desc(color_spec, False)
         if color_id is None:
             raise Exception("color spec not recognized")
-        return ColorSet.from_color_ids(self.model, [color_id])
+        return ColorSet.from_color_ids(self.model.get_color_map(), [color_id])
 
     def select_inputs(self, color_set, t_value):
         cq = self.model.make_coin_query({"color_set": color_set})

--- a/ngcccbase/txcons.py
+++ b/ngcccbase/txcons.py
@@ -102,7 +102,7 @@ class SimpleOperationalTxSpec(txspec.OperationalTxSpec):
         wam = self.model.get_address_manager()
         color_set = None
         if color_def == colordef.UNCOLORED_MARKER:
-            color_set = ColorSet.from_color_ids(self.model, [0])
+            color_set = ColorSet.from_color_ids(self.model.get_color_map(), [0])
         elif self.asset.get_color_set().has_color_id(color_id):
             color_set = self.asset.get_color_set()
         if color_set is None:


### PR DESCRIPTION
...nlib
- refactored ColorSet to use colormap instead of model
- moved ColorSet into coloredcoinlib under colorset.py
- added unit tests for colorset.py in tests/test_colorset.py
- fixed a bug found from unit testing in colorset.py for get_earliest
- added coloredcoinlib/**init**.py so wallet_model isn't so verbose
