### PR TITLE
Issue #129: Add client side for chroma server processing

### DIFF
--- a/coloredcoinlib/builder.py
+++ b/coloredcoinlib/builder.py
@@ -134,9 +134,13 @@ class FullScanColorDataBuilder(BasicColorDataBuilder):
         self.scan_blockchain(blocklist)
 
 
-class AidedColorDataBuilder(FullScanColorDataBuilder):
+class AidedColorDataBuilder(BasicColorDataBuilder):
     """Color data builder based on following output spending transactions
         from the color's genesis transaction output, for one specific color"""
+
+    def __init__(self, cdstore, blockchain_state, colordef, metastore):
+        super(AidedColorDataBuilder, self).__init__(
+            cdstore, blockchain_state, colordef, metastore)
 
     def scan_blockchain(self, blocklist):
         txo = self.colordef.genesis.copy()

--- a/ngccc-cli.py
+++ b/ngccc-cli.py
@@ -1,5 +1,5 @@
-
 #!/usr/bin/env python
+
 """
 ngccc-cli.py
 

--- a/ngcccbase/services/chroma.py
+++ b/ngcccbase/services/chroma.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+"""
+chroma.py
+
+This is a connector to chromawallet's servers to grab transaction details
+"""
+
+import bitcoin
+import json
+import urllib2
+
+from coloredcoinlib.blockchain import CTransaction
+
+
+class UnimplementedError(RuntimeError):
+    pass
+
+
+class ChromaBlockchainState:
+
+    tx_lookup = {}
+
+    @classmethod
+    def from_url(cls, url, testnet=False):
+        return cls()
+
+    def __init__(self, url="localhost", port=28832):
+        """Initialization takes the url and port of the chroma server.
+        We have to use the chroma server for everything that we would
+        use 
+        We use the normal bitcoind interface, except for
+        get_raw_transaction, where we have to do separate lookups
+        to blockchain and electrum.
+        """
+        self.url_stem = "http://%s:%s" % (url, port)
+
+    def prefetch(self, txhash, output_set, color_desc, limit):
+        url = "%s/prefetch" % self.url_stem
+        data = {'txhash': txhash, 'output_set': output_set,
+                'color_desc': color_desc, 'limit': limit}
+        req = urllib2.Request(url, json.dumps(data),
+                              {'Content-Type': 'application/json'})
+        f = urllib2.urlopen(req)
+        txs = json.loads(f.read())
+        for txhash, txraw in txs.items():
+            self.tx_lookup[txhash] = txraw
+        f.close()
+        return
+
+    def get_raw(self, txhash):
+        if self.tx_lookup.get(txhash):
+            return self.tx_lookup[txhash]
+        url = "%s/tx" % self.url_stem
+        data = {'txhash': txhash}
+        req = urllib2.Request(url, json.dumps(data),
+                              {'Content-Type': 'application/json'})
+        f = urllib2.urlopen(req)
+        payload = f.read()
+        self.tx_lookup[txhash] = payload
+        f.close()
+        return payload
+
+    def get_tx(self, txhash):
+        txhex = self.get_raw(txhash)
+        txbin = bitcoin.core.x(txhex)
+        tx = bitcoin.core.CTransaction.deserialize(txbin)
+        return CTransaction.from_bitcoincore(txhash, tx, self)
+
+    def get_mempool_txs(self):
+        return []
+

--- a/server/run.py
+++ b/server/run.py
@@ -27,7 +27,7 @@ class ErrorThrowingRequestProcessor:
 class Tx(ErrorThrowingRequestProcessor):
     def POST(self):
         # data is sent in as json
-        data = json.loads(web.input().keys()[0])
+        data = json.loads(web.data())
         self.require(data, 'txhash', "TX requires txhash")
         txhash = data.get('txhash')
         return blockchainstate.get_raw(txhash)
@@ -36,7 +36,7 @@ class Tx(ErrorThrowingRequestProcessor):
 class Prefetch(ErrorThrowingRequestProcessor):
     def POST(self):
         # data is sent in as json
-        data = json.loads(web.input().keys()[0])
+        data = json.loads(web.data())
         self.require(data, 'txhash', "Prefetch requires txhash")
         self.require(data, 'output_set', "Prefetch requires output_set")
         self.require(data, 'color_desc', "Prefetch requires color_desc")
@@ -44,8 +44,12 @@ class Prefetch(ErrorThrowingRequestProcessor):
         output_set = data.get('output_set')
         color_desc = data.get('color_desc')
         limit = data.get('limit')
-        color_def = ColorDefinition.from_color_desc(17, color_desc)
 
+        # note the id doesn't actually matter we need to add it so
+        #  we have a valid color definition
+        color_def = ColorDefinition.from_color_desc(9999, color_desc)
+
+        # gather all the transactions and return them
         tx_lookup = {}
 
         def process(current_txhash, current_outindex):
@@ -72,6 +76,7 @@ class Prefetch(ErrorThrowingRequestProcessor):
         for oi in output_set:
             process(txhash, oi)
         return tx_lookup
+
 
 if __name__ == "__main__":
     app = web.application(urls, globals())

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requires = [
     'bunch',
     'python-jsonrpc',
     'python-bitcoinlib',
+    'web.py',
 ]
 
 dependency_links = [


### PR DESCRIPTION
- Changed up AidedColorDataBuilder to subclass BasicColorDataBuilder instead of FullScanColorDataBuilder
- Changed color.py to use ThinColorData/AidedColorDataBuilder/ChromaBlockchainState based on a key (for now default)
- Added chroma.py in services as the client to a chroma server (note prefetch isn't used yet)
- Added web.py to the setup.py
- Changed run.py on the server to be a little cleaner
